### PR TITLE
Updated calendar ID to interviewme.business@gmail.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .idea
+key.json
 src/test/java/com/google/sps/do_not_test_with_git

--- a/src/main/java/com/google/sps/data/GoogleCalendarAccess.java
+++ b/src/main/java/com/google/sps/data/GoogleCalendarAccess.java
@@ -40,7 +40,7 @@ import java.util.Collections;
 // Handles all things Google Calendar (for now just getting a Meet link).
 public class GoogleCalendarAccess implements CalendarAccess {
   private Calendar service;
-  private static final String CALENDAR_ID = "info@jqed.dev";
+  private static final String CALENDAR_ID = "interviewme.business@gmail.com";
 
   // TODO: remember to write tests in the code that calls CalendarAccess() that handle what happens
   // per each exception

--- a/src/main/java/com/google/sps/data/SendgridEmailSender.java
+++ b/src/main/java/com/google/sps/data/SendgridEmailSender.java
@@ -38,9 +38,7 @@ public class SendgridEmailSender implements EmailSender {
 
   public SendgridEmailSender(Email sender) throws IOException {
     this.sender = sender;
-    this.sg =
-        new SendGrid(
-            new SecretFetcher("interviewme2020").getSecretValue("SENDGRID_API_KEY"));
+    this.sg = new SendGrid(new SecretFetcher("interviewme2020").getSecretValue("SENDGRID_API_KEY"));
   }
 
   // Sends an email from the "sender" Email to the "recipient" Email, with specified subject and


### PR DESCRIPTION
Will not use info@jqed.dev's calendar anymore
key.json was needed to use application default credentials since we aren't using the shell editor anymore
SendgridEmailSender changes was just formatting